### PR TITLE
Fix colors package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "ajv": "^8.0.2",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "commander": "^7.2.0",
     "glob": "^7.1.6",
     "goerwin-ts-helpers": "^1.1.0",


### PR DESCRIPTION
To prevent the meltdown of the author of colors (1.4.1) to cause directory-validator to spam to the console.